### PR TITLE
Namespace config_get and _set calls; allow module to install cleanly.

### DIFF
--- a/imce_mkdir.install
+++ b/imce_mkdir.install
@@ -10,7 +10,7 @@
  */
 function imce_mkdir_install() {
   // Update profiles. Add mkdir settings.
-  $profiles = config_get('imce_profiles', array());
+  $profiles = config_get('imce.imce_profiles', array());
   foreach ($profiles as $i => $profile) {
     foreach ($profile['directories'] as $j => $directory) {
       $profiles[$i]['directories'][$j]['mkdir'] = $i == 1 ? 1 : 0;
@@ -18,17 +18,17 @@ function imce_mkdir_install() {
     }
     $profiles[$i]['mkdirnum'] = $i == 1 ? 0 : 2;
   }
-  config_set('imce_profiles', $profiles);
+  config_set('imce.imce_profiles', $profiles);
 
   // Register custom content function
-  $funcs = config_get('imce_custom_content', array());
+  $funcs = config_get('imce.imce_custom_content', array());
   $funcs['imce_mkdir_content'] = 1;
-  config_set('imce_custom_content', $funcs);
+  config_set('imce.imce_custom_content', $funcs);
 
   // Register custom profile process
-  $funcs = config_get('imce_custom_process', array());
+  $funcs = config_get('imce.imce_custom_process', array());
   $funcs['imce_mkdir_process_profile'] = 1;
-  config_set('imce_custom_process', $funcs);
+  config_set('imce.imce_custom_process', $funcs);
 }
 
 /**
@@ -36,22 +36,22 @@ function imce_mkdir_install() {
  */
 function imce_mkdir_uninstall() {
   // Update profiles. Delete mkdir settings.
-  $profiles = config_get('imce_profiles', array());
+  $profiles = config_get('imce.imce_profiles', array());
   foreach ($profiles as $i => $profile) {
     foreach ($profile['directories'] as $j => $directory) {
       unset($profiles[$i]['directories'][$j]['mkdir'], $profiles[$i]['directories'][$j]['rmdir']);
     }
     unset($profiles[$i]['mkdirnum']);
   }
-  config_set('imce_profiles', $profiles);
+  config_set('imce.imce_profiles', $profiles);
 
   // Unregister custom content function
-  $funcs = config_get('imce_custom_content', array());
+  $funcs = config_get('imce.imce_custom_content', array());
   unset($funcs['imce_mkdir_content']);
-  config_set('imce_custom_content', $funcs);
+  config_set('imce.imce_custom_content', $funcs);
 
   // Unregister custom profile process
-  $funcs = config_get('imce_custom_process', array());
+  $funcs = config_get('imce.imce_custom_process', array());
   unset($funcs['imce_mkdir_process_profile']);
-  config_set('imce_custom_process', $funcs);
+  config_set('imce.imce_custom_process', $funcs);
 }


### PR DESCRIPTION
@danielrose28 this namespaces the config calls so it knows which module to get and set config in; in this case `imce`.

Allows the `imce_mkdir` module to install cleanly.